### PR TITLE
fix: export correct file for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ],
     "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>"
   },
-  "main": "src/certificate-helpers.js",
+  "main": "src/certificate.js",
   "scripts": {
     "posttest": "eslint src test",
     "test": "npm run unit-tests",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The export for this npm package references a `src/certificate-helpers.js` which was renamed to `src/certificate.js`. This PR fixes this reference.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
