### PR TITLE
fix: add subjectAltNames

### DIFF
--- a/src/certificate.js
+++ b/src/certificate.js
@@ -90,6 +90,13 @@ function generate (commonName, days, /* istanbul ignore next */ attributes = {})
       codeSigning: true,
       emailProtection: true,
       timeStamping: true
+    },
+    {
+      name: 'subjectAltName',
+      altNames: [{
+        type: 2, // DNS
+        value: commonName
+      }]
     }
   ])
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add subjectAltNames extension to generated certificate, by adding the specifier object to the call to `cert.setExtensions` in `certificate.js`.
Add unit test. 

<!--- Describe your changes in detail -->

## Related Issue
Closes https://github.com/adobe/aio-cli/issues/260

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Local trust for local development requires it. See https://github.com/adobe/aio-cli/issues/260

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
With unit tests!

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1643758/113930669-317cbd80-97b7-11eb-8edf-29ea3c0540b0.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
