### PR TITLE
feat: assets-11385. add fingerprint command

### DIFF
--- a/src/commands/certificate/fingerprint.js
+++ b/src/commands/certificate/fingerprint.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command } = require('@oclif/command')
+const fs = require('fs-extra')
+const debug = require('debug')('aio-cli-plugin-certificate:fingerprint')
+
+const cert = require('../../certificate')
+
+class FingerprintCommand extends Command {
+  async run () {
+    const { args } = this.parse(FingerprintCommand)
+
+    if (!fs.existsSync(args.file)) {
+      this.error('input file does not exist: ' + args.file)
+    }
+
+    try {
+      const pemCert = fs.readFileSync(args.file).toString()
+      debug('fingerprinting cert from pem: ', pemCert)
+      // this will throw if file is not a valid pem content
+      const res = cert.fingerprint(pemCert)
+
+      this.log(res.certificateFingerprint)
+      return res.certificateFingerprint
+    } catch (err) {
+      debug('error fingerprinting certificate: ', err)
+      this.error(err.message)
+    }
+  }
+}
+
+FingerprintCommand.description = 'Compute the fingerprint of a public key certificate for use with Adobe I/O'
+
+FingerprintCommand.args = [
+  {
+    name: 'file',
+    required: true,
+    description: 'file path to certificate to fingerprint'
+  }
+]
+
+module.exports = FingerprintCommand

--- a/test/commands/certificate/fingerprint.test.js
+++ b/test/commands/certificate/fingerprint.test.js
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// const { stdout } = require('stdout-stderr')
+const commandPath = '../../../src/commands/certificate/fingerprint'
+let TheCommand
+jest.isolateModules(() => {
+  TheCommand = require(commandPath)
+})
+
+const validCertPem = `
+  -----BEGIN CERTIFICATE-----
+MIIDMTCCAhmgAwIBAgIHAWVCcDJVYDANBgkqhkiG9w0BAQsFADAdMRswGQYDVQQD
+ExJHZW5lcmF0ZWQgS2V5IFBhaXIwHhcNMjIwNjAzMTUzMjA1WhcNMjMwNjAzMTUz
+MjA1WjAdMRswGQYDVQQDExJHZW5lcmF0ZWQgS2V5IFBhaXIwggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQC7vbn/WhI16mKvcYuox+NXOmlcXkieHZL2N6po
+2f0Dv4WmtYNHxMbLzsP7zGeKm4DRGSs4Qwnk/NsD7KA9pILmT8aXHVfxrJhCawuz
+WTUNjfp8sWGCjhOSHemN9BBo5TP4+Ht/xqE9ANG9mjHhaRUQVa8BAivDDibgC2cs
+8AoA5JlDA515ShhnWFLG6wL3IObVzJIJip4chrh26r5La6l76D++LztSnDgYvfzY
+J3iCdxaMh/507IVpqc5Vl4pfY5Kp9yF91Z7tD1OTyEpps9ySGiN+rHBJfvixdKUI
+gLm5VkeR3hpl7g8+NJSlxo4e/9znQ45OytZHdLk/pVkEkUxXAgMBAAGjdjB0MAkG
+A1UdEwQCMAAwCwYDVR0PBAQDAgL0MDsGA1UdJQQ0MDIGCCsGAQUFBwMBBggrBgEF
+BQcDAgYIKwYBBQUHAwMGCCsGAQUFBwMEBggrBgEFBQcDCDAdBgNVHREEFjAUghJH
+ZW5lcmF0ZWQgS2V5IFBhaXIwDQYJKoZIhvcNAQELBQADggEBAGdiHZP/SA/8ejgE
+1ZbRmvRJMhYz17K5KzB/3wujhRKl2OBKjnv3PVk15Pc6IHabkPKV0PtUKXPfxSci
+mwj+3s2R3pRW4S6OhpNYg5/3caPGWXIVmQWJQqo1LdEnD2tpblghVRiha25QBnsi
+0wk7l9ebV683A+n6u0Xn9fjFnlT+j7lG36px03z1K+dOQj0+j0yrda9SUSBCYcJj
+4+PE1kwOSDRpAnb7mO5BOoSR/x67bQU5kcKcE8kVIijWmuxoyQn6LQEZzKP5LT4F
+6DZssT8ZOJuWr7d+BUapoVO1D5o4CrFwYjsHss77tgybTMXQjKsPnkhns8M8RxqW
+B9+DCYg=
+-----END CERTIFICATE-----
+`
+const validCertFingerprint = '38f65e26bd3869ec3ca029cc0b3df98de29172b9'
+
+test('exports', async () => {
+  expect(typeof TheCommand).toEqual('function')
+})
+
+test('description', async () => {
+  expect(TheCommand.description).toBeDefined()
+})
+
+test('args', async () => {
+  const arg = TheCommand.args[0]
+  expect(arg.name).toBeDefined()
+})
+
+describe('instance methods - mock forge', () => {
+  let CommandUnderTest, command, handleError, mockFS, mockForge
+  jest.isolateModules(() => {
+    CommandUnderTest = require(commandPath)
+    mockFS = require('fs-extra')
+    mockForge = require('node-forge')
+    jest.mock('node-forge')
+  })
+
+  beforeEach(() => {
+    command = new CommandUnderTest([])
+    handleError = jest.spyOn(command, 'error')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('run missing args', async () => {
+    expect(command.run).toBeDefined()
+    command.argv = []
+    await expect(command.run()).rejects.toThrow(/Missing 1 required arg/)
+  })
+
+  test('run -- input file not found', async () => {
+    mockFS.existsSync.mockReturnValue(false)
+    command.argv = ['file-not-found']
+    await expect(command.run()).rejects.toThrow()
+    expect(handleError).toHaveBeenCalledWith(expect.stringMatching(/input file does not exist/))
+  })
+
+  test('run with invalid file ( not a pem )', async () => {
+    mockFS.existsSync.mockReturnValue(true)
+    mockFS.readFileSync.mockReturnValue('not a pem')
+    mockForge.pki.certificateFromPem.mockImplementation(() => { throw new Error('Not Verified') })
+    command.argv = ['file']
+    await expect(command.run()).rejects.toThrow(/Not Verified/)
+    expect(handleError).toHaveBeenCalled()
+  })
+})
+
+describe('instance methods - real forge', () => {
+  let CommandUnderTest, command, handleError, mockFS
+  jest.isolateModules(() => {
+    mockFS = require('fs-extra')
+    jest.unmock('node-forge')
+    CommandUnderTest = require(commandPath)
+  })
+
+  beforeEach(() => {
+    command = new CommandUnderTest([])
+    handleError = jest.spyOn(command, 'error')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('run with valid cert pem', async () => {
+    mockFS.existsSync.mockReturnValue(true)
+    mockFS.readFileSync.mockReturnValue(Buffer.from(validCertPem))
+    command.argv = ['file']
+    await expect(command.run()).resolves.toBe(validCertFingerprint)
+    expect(handleError).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `certificate:fingerprint` command that computes the SHA1 fingerprint used by the Adobe I/O Developer Console for a local x509 certificate file like one that is created by `certificate:generate`. 

```bash
$ aio -h certificate:fingerprint
Compute the fingerprint of a public key certificate for use with Adobe I/O

USAGE
  $ aio certificate:fingerprint FILE

ARGUMENTS
  FILE  file path to certificate to fingerprint

$ aio certificate:fingerprint certificate_pub.crt
38f65e26bd3869ec3ca029cc0b3df98de29172b9
$ cat certificate_pub.crt
-----BEGIN CERTIFICATE-----
MIIDMTCCAhmgAwIBAgIHAWVCcDJVYDANBgkqhkiG9w0BAQsFADAdMRswGQYDVQQD
ExJHZW5lcmF0ZWQgS2V5IFBhaXIwHhcNMjIwNjAzMTUzMjA1WhcNMjMwNjAzMTUz
MjA1WjAdMRswGQYDVQQDExJHZW5lcmF0ZWQgS2V5IFBhaXIwggEiMA0GCSqGSIb3
DQEBAQUAA4IBDwAwggEKAoIBAQC7vbn/WhI16mKvcYuox+NXOmlcXkieHZL2N6po
2f0Dv4WmtYNHxMbLzsP7zGeKm4DRGSs4Qwnk/NsD7KA9pILmT8aXHVfxrJhCawuz
WTUNjfp8sWGCjhOSHemN9BBo5TP4+Ht/xqE9ANG9mjHhaRUQVa8BAivDDibgC2cs
8AoA5JlDA515ShhnWFLG6wL3IObVzJIJip4chrh26r5La6l76D++LztSnDgYvfzY
J3iCdxaMh/507IVpqc5Vl4pfY5Kp9yF91Z7tD1OTyEpps9ySGiN+rHBJfvixdKUI
gLm5VkeR3hpl7g8+NJSlxo4e/9znQ45OytZHdLk/pVkEkUxXAgMBAAGjdjB0MAkG
A1UdEwQCMAAwCwYDVR0PBAQDAgL0MDsGA1UdJQQ0MDIGCCsGAQUFBwMBBggrBgEF
BQcDAgYIKwYBBQUHAwMGCCsGAQUFBwMEBggrBgEFBQcDCDAdBgNVHREEFjAUghJH
ZW5lcmF0ZWQgS2V5IFBhaXIwDQYJKoZIhvcNAQELBQADggEBAGdiHZP/SA/8ejgE
1ZbRmvRJMhYz17K5KzB/3wujhRKl2OBKjnv3PVk15Pc6IHabkPKV0PtUKXPfxSci
mwj+3s2R3pRW4S6OhpNYg5/3caPGWXIVmQWJQqo1LdEnD2tpblghVRiha25QBnsi
0wk7l9ebV683A+n6u0Xn9fjFnlT+j7lG36px03z1K+dOQj0+j0yrda9SUSBCYcJj
4+PE1kwOSDRpAnb7mO5BOoSR/x67bQU5kcKcE8kVIijWmuxoyQn6LQEZzKP5LT4F
6DZssT8ZOJuWr7d+BUapoVO1D5o4CrFwYjsHss77tgybTMXQjKsPnkhns8M8RxqW
B9+DCYg=
-----END CERTIFICATE-----
```

## Related Issue

https://jira.corp.adobe.com/browse/ASSETS-11385

## Motivation and Context

It is important that the SHA-1 fingerprint of a local certificate file can be determined before attempting to upload the certificate to the entp bindings service endpoint, because it serves as a primary key for the key pair across organizations and as a foreign key for bindings within an integration. This aio cli plugin is the perfect place to maintain it, so that if the format of the fingerprint on the server side has to change for any reason, this plugin can remain the authoritative implementation on the client side.

I've determined that the fingerprint used by the Adobe I/O Developer Console and the Enterprise Integrations bindings services is the same as that generated by openssl x509 -fingerprint , but without delimiters, and with lowercase hexadecimal letters.

According to a [trusted authority](https://stackoverflow.com/a/4825790), the openssl x509 fingerprint is a SHA1 digest over the DER-encoded x509 structure, after decoding from PEM.

This logic should also be made accessible to other aio cli plugins and libraries that already consume the certificate.js module from aio-cli-plugin-certificate for generation and verification, to avoid duplicating dependencies on complicated PKI libraries.

## How Has This Been Tested?

Added unit tests, as well as executed locally, using the following linked aio-cli modules:
 
- [@adobe/aio-lib-console PR#33](https://github.com/adobe/aio-lib-console/pull/33)
- [@adobe/aio-cli-lib-console PR#44](https://github.com/adobe/aio-cli-lib-console/pull/44)
- [@adobe/aio-cli-plugin-console PR#173](https://github.com/adobe/aio-cli-plugin-console/pull/173)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
