### PR TITLE
fix: ACNA-2805 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ DESCRIPTION
   Generate, fingerprint, or verify a certificate for use with Adobe I/O
 ```
 
-_See code: [src/commands/certificate/index.ts](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/index.ts)_
+_See code: [src/commands/certificate/index.js](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/index.js)_
 
 ## `aio certificate fingerprint FILE`
 
@@ -59,7 +59,7 @@ DESCRIPTION
   Compute the fingerprint of a public key certificate for use with Adobe I/O
 ```
 
-_See code: [src/commands/certificate/fingerprint.ts](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/fingerprint.ts)_
+_See code: [src/commands/certificate/fingerprint.js](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/fingerprint.js)_
 
 ## `aio certificate generate`
 
@@ -88,7 +88,7 @@ DESCRIPTION
   services.
 ```
 
-_See code: [src/commands/certificate/generate.ts](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/generate.ts)_
+_See code: [src/commands/certificate/generate.js](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/generate.js)_
 
 ## `aio certificate verify FILE`
 
@@ -109,7 +109,7 @@ DESCRIPTION
   Verifies that the certificate is valid, and/or will not expire in [--days] days from now.
 ```
 
-_See code: [src/commands/certificate/verify.ts](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/verify.ts)_
+_See code: [src/commands/certificate/verify.js](https://github.com/adobe/aio-cli-plugin-certificate/blob/2.0.0/src/commands/certificate/verify.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node-forge": "^1.3.0"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.2",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "eslint": "^8.56.0",
     "eslint-config-oclif": "^4.0.0",
     "eslint-config-standard": "^17.1.0",
@@ -22,9 +22,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.3.3",
-    "oclif": "^3.2.0"
+    "oclif": "^3.2.0",
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #32 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

