### PR TITLE
fix: remove return value from fingerprint command

### DIFF
--- a/src/commands/certificate/fingerprint.js
+++ b/src/commands/certificate/fingerprint.js
@@ -31,7 +31,6 @@ class FingerprintCommand extends Command {
       const res = cert.fingerprint(pemCert)
 
       this.log(res.certificateFingerprint)
-      return res.certificateFingerprint
     } catch (err) {
       debug('error fingerprinting certificate: ', err)
       this.error(err.message)

--- a/test/commands/certificate/fingerprint.test.js
+++ b/test/commands/certificate/fingerprint.test.js
@@ -116,7 +116,9 @@ describe('instance methods - real forge', () => {
     mockFS.existsSync.mockReturnValue(true)
     mockFS.readFileSync.mockReturnValue(Buffer.from(validCertPem))
     command.argv = ['file']
-    await expect(command.run()).resolves.toBe(validCertFingerprint)
+    const logSpy = jest.spyOn(command, 'log')
+    await expect(command.run()).resolves.toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(validCertFingerprint)
     expect(handleError).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes #83 

## Summary
- Removes the `return res.certificateFingerprint` from the `fingerprint` command's `run()` method
- oclif commands should not return values; output is already logged via `this.log()`

## Test plan
- [x] Run `aio certificate fingerprint <cert-file>` and verify the fingerprint is still printed to stdout
- [x] Verify no regression in other certificate commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)